### PR TITLE
Fix Surplus.appendChild undefined error (bump to 0.5.0-beta4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-surplus",
-  "version": "0.5.0-beta1",
+  "version": "0.5.0-beta4",
   "description": "A rollup plugin to compile Surplus JSX views",
   "author": "Adam Haile",
   "repository": "https://github.com/adamhaile/rollup-plugin-surplus",
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "surplus": "^0.5.0-beta1"
+    "surplus": "^0.5.0-beta4"
   },
   "dependencies": {
     "rollup-pluginutils": "^1.5.0"


### PR DESCRIPTION
Dear Adam,

It's currently not possible to build surplus 0.5.0-**beta4** with rollup-plugin-surplus. 
rollup-plugin-surplus needs to depend from surplus 0.5.0-**beta4**  instead of 0.5.0-**beta1**

Have a nice day 
